### PR TITLE
Add Next.js layout example with AIDevtools integration for developmen…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,28 @@ function App() {
 }
 ```
 
+### Next.js — place in `app/layout.tsx`
+
+```tsx
+// app/layout.tsx (Server Component)
+import type { Metadata } from 'next';
+import { AIDevtools } from 'ai-sdk-devtools';
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {children}
+        {process.env.NODE_ENV === 'development' && (
+          <AIDevtools />
+        )}
+      </body>
+    </html>
+  );
+}
+```
+
+
 ### With useChat Integration
 
 ```tsx

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ function App() {
 ### Next.js — place in `app/layout.tsx`
 
 ```tsx
-// app/layout.tsx (Server Component)
 import type { Metadata } from 'next';
 import { AIDevtools } from 'ai-sdk-devtools';
 


### PR DESCRIPTION
It would be convenient to place this at the `Layout` level on Next.js apps (as usually done by debug tools)

However, there's a blocker. The `AIDevtools` is not being recognized as a client component, even though the `"use client"` directive is in the code file.

Maybe `vite build` is stripping it? 

https://www.reddit.com/r/reactjs/comments/1bpaeso/vite_preserve_use_client_directive_when_building/